### PR TITLE
feat: メッセージ更新を非同期でバッチ処理するように変更

### DIFF
--- a/spec/非同期メッセージ更新.md
+++ b/spec/非同期メッセージ更新.md
@@ -1,0 +1,136 @@
+# 非同期メッセージ更新（バッチ + デバウンス）
+
+## 1. 目的
+
+`MessageUpdateManager.updateRelatedMessages(event)` はコストが高く、短時間に連続で呼ばれると不要な更新が多発する。更新要求を一旦キューに蓄積し、最後の操作から一定時間（約1分）アイドル状態が続いたタイミングで、まとめて非同期実行することで、更新回数と負荷を削減する。
+
+## 2. 仕様概要
+
+- 対象: イベントに紐づく全ての関連メッセージ更新（既存の `updateRelatedMessages` を流用）。
+- 動作: グローバルなデバウンス + バッチ実行。
+  - 更新要求（イベントID）をキューに積む。
+  - 最後に要求を受け付けた時刻から「遅延時間（既定: 60秒）」アイドルが続いたら、キュー内の全イベントをまとめて更新。
+  - 遅延時間内に追加の操作（更新要求）があれば、実行時刻をその時点から再度「遅延時間」後に延期する。
+- まとめ方: イベントIDで重複を排除（Set）。1バッチ内で各イベントは1回だけ更新する。
+- 実行中の再要求: 実行中に新しい要求が来た場合は次バッチへ回す（実行を中断しない）。
+- 優先度・順序: なし（Setを配列化した順番で逐次更新）。
+- 同時実行: 1ワーカー（逐次）で処理。Discordのレート制限を考慮し、同時更新は行わない。
+
+## 3. インターフェース
+
+### 3.1 コンポジション（推奨）またはインナークラス
+
+- 新規クラスを用意し、`MessageUpdateManager` がそれをコンポジションする。
+- 実装は下記のどちらでも可（推奨はコンポジション）。
+  - コンポジション: 別ファイル `MessageUpdateScheduler` を作成し、`MessageUpdateManager` がインスタンスを保持。
+  - インナークラス: `MessageUpdateManager` 内に `Scheduler` クラスをネストし、同様にインスタンスを保持。
+
+#### MessageUpdateScheduler（共通インターフェース）
+
+```ts
+export class MessageUpdateScheduler {
+  constructor(
+    private readonly manager: MessageUpdateManager,
+    private readonly debounceMs = 60_000,
+  ) {}
+
+  // 更新要求を追加（イベントIDまたは EventWithHost を受け付け）
+  enqueue(event: number | EventWithHost): void;
+
+  // 今すぐ実行（デバッグ・緊急用）。保留分を即時フラッシュして実行する。
+  flushNow(): Promise<void>;
+}
+```
+
+- 実装要点（スケジューラ内）:
+  - 内部状態
+    - `pending: Set<number>`（重複排除）
+    - `timer: NodeJS.Timeout | null`
+    - `running: boolean`（実行中フラグ）
+    - `lastEnqueueAt: number`（最後に enqueue した時刻）
+  - `enqueue(...)`
+    - `pending.add(eventId)`
+    - `lastEnqueueAt = Date.now()`
+    - 既存タイマーがあればクリアし、`debounceMs` 後に `runBatch()` を予約
+  - `runBatch()`
+    - `running = true`
+    - 直前にスナップショット（`const batch = Array.from(pending); pending.clear()`）
+    - 各イベントIDについて DB から `EventWithHost` を取得して `manager.updateRelatedMessages(event)` を await で逐次実行
+    - 終了時に `running = false`
+    - 実行中に `enqueue` されたイベントが `pending` に残っていれば、`lastEnqueueAt + debounceMs` を満たすように次のタイマーを再セット
+  - エラーハンドリング
+    - イベント単位で try/catch。失敗はログ出力して続行
+    - バッチ全体が失敗してもプロセスは継続
+
+### 3.2 既存コードからの利用
+
+- 露出方法は2択（どちらでも可）:
+  - `MessageUpdateManager` が表に `enqueue/flushNow` をフォワードする
+  - `messageUpdateScheduler` を直接 import して呼び出す
+
+- これまで直接 `messageUpdateManager.updateRelatedMessages(event)` を呼んでいた箇所は、基本的に以下に置き換える
+
+```ts
+// フォワードAPIを持たせる場合
+messageUpdateManager.enqueue(updatedEvent.id);
+
+// 直接呼び出す場合
+messageUpdateScheduler.enqueue(updatedEvent.id);
+```
+
+- 即時反映が望ましい箇所のみ、従来どおり直接呼び出してよい（例: 明示的な「今すぐ更新」コマンドを実装する場合など）。
+
+## 4. トリガー（主な置き換え候補）
+
+以下のような「イベント状態を更新した後に関連メッセージを更新」している箇所を、`enqueue` へ置き換える。
+
+- `src/commands/action/event_setup_command/SetupUserSelectAction.ts`
+- `src/commands/action/event_setup_command/SetupPreparerSelectAction.ts`
+- `src/commands/action/preparation_status_command/PreparationStatusToggleSelectAction.ts`
+- `src/commands/action/event_panel_command/PanelStopButtonAction.ts`
+- `src/commands/event_op_command/EventOpPanelCommand.ts`
+- その他、`messageUpdateManager.updateRelatedMessages(...)` を直接呼んでいる箇所
+
+## 5. 設定
+
+- 既定値: `debounceMs = 60_000`（60秒）
+- 変更可能にする場合は `run/config.default.toml` などの設定ファイルに `message_update.debounce_ms` を追加し、未指定時は既定値を使用。
+
+## 6. ログ・可観測性
+
+- `enqueue`: 追加時にイベントIDと保留件数を debug で記録（スパム回避のため info はバッチ開始/終了のみ）
+- バッチ開始: 件数、対象IDのサマリ、開始時刻
+- 各イベント: 成功/失敗を info/error で出力（既存 `MessageUpdateManager` のログ方針に合わせる）
+- バッチ終了: 処理件数、所要時間、失敗件数
+
+## 7. 擬似タイムライン例
+
+- t=0s: `enqueue(10)` → 次回実行を t=60s に予約
+- t=30s: `enqueue(12)` → 次回実行を t=90s にリスケジュール
+- t=70s: `enqueue(10)` → 次回実行を t=130s にリスケジュール（10は重複登録されない）
+- t=130s: バッチ実行 → 対象: {10,12}
+
+## 8. エラーハンドリングと再試行
+
+- イベント単位の更新失敗はログのみ。自動再試行は行わない（簡潔化）。
+- 必要に応じて将来的に「軽いリトライ（例: 1回のみ・数秒後）」や「指数バックオフ付きの再試行キュー」を導入可能。
+
+## 9. 終了・再起動時の扱い
+
+- キューの永続化は行わない（プロセス内メモリ）。
+- 再起動で保留分は失われるが、次の操作時に再度 `enqueue` される前提。
+
+## 10. 実装タスク
+
+1. スケジューラクラスを実装（コンポジション or インナークラス）。
+2. `MessageUpdateManager` にインスタンスを保持し、`enqueue/flushNow` をフォワード or 別exportで公開。
+3. 既存呼び出し箇所を `enqueue(event.id)` に置換（フォワード経由 or 直接呼び出し）。
+4. 設定値を導入する場合は `config` 経由で `debounceMs` を注入可能にする。
+5. 主要フローでの動作確認（ショートデバウンスで手動検証）。
+
+## 11. 非機能要件・留意事項
+
+- デバウンスは「グローバル（プロセス全体）」であり、どのイベントの操作でもタイマーが延長される。
+- バッチの逐次実行は Discord のレート制限回避を優先（並列化はしない）。
+- `updateRelatedMessages` のインターフェースや既存ロジックは変更しない（互換維持）。
+- 即時反映が必要なケースは明示的に直接呼ぶ（設計上の例外を許容）。

--- a/src/commands/action/event_panel_command/PanelStopButtonAction.ts
+++ b/src/commands/action/event_panel_command/PanelStopButtonAction.ts
@@ -156,18 +156,9 @@ class PanelStopButtonAction extends MessageComponentActionInteraction<ComponentT
       await onEndEvent(eventAfterStop, scheduledEvent.channel);
     }
 
-    // イベントに関連する全メッセージを汎用的に更新
-    try {
-      const updatedMessages =
-        await messageUpdateManager.updateRelatedMessages(event);
-      logger.info(
-        `イベント ${event.id} の関連メッセージ ${updatedMessages.length} 件を更新`,
-      );
-    } catch (error) {
-      logger.error(
-        `関連メッセージ更新中にエラーが発生しました: ${String(error)}`,
-      );
-    }
+    // イベントに関連する全メッセージの更新をスケジュール
+    messageUpdateManager.enqueue(event.id);
+    logger.info(`イベント ${event.id} の関連メッセージ更新をスケジュール`);
 
     // アナウンスチャンネルのスレッド処理
     if (

--- a/src/commands/action/event_setup_command/SetupPreparerSelectAction.ts
+++ b/src/commands/action/event_setup_command/SetupPreparerSelectAction.ts
@@ -104,19 +104,12 @@ class SetupPreparerSelectAction extends MessageComponentActionInteraction<Compon
       ...eventIncludeHost,
     });
 
-    // イベントに関連する全メッセージを更新
+    // イベントに関連する全メッセージの更新をスケジュール
     if (updatedEvent) {
-      try {
-        const updatedMessages =
-          await messageUpdateManager.updateRelatedMessages(updatedEvent);
-        logger.info(
-          `準備者変更によりイベント ${updatedEvent.id} の関連メッセージ ${updatedMessages.length} 件を更新`,
-        );
-      } catch (error) {
-        logger.error(
-          `関連メッセージ更新中にエラーが発生しました: ${String(error)}`,
-        );
-      }
+      messageUpdateManager.enqueue(updatedEvent.id);
+      logger.info(
+        `準備者変更によりイベント ${updatedEvent.id} の関連メッセージ更新をスケジュール`,
+      );
     }
 
     // パネルを表示

--- a/src/commands/action/event_setup_command/SetupUserSelectAction.ts
+++ b/src/commands/action/event_setup_command/SetupUserSelectAction.ts
@@ -109,19 +109,12 @@ class SetupUserSelectAction extends MessageComponentActionInteraction<ComponentT
       await eventManager.updateEventDescription(scheduledEvent, updatedEvent);
     }
 
-    // イベントに関連する全メッセージを更新
+    // イベントに関連する全メッセージの更新をスケジュール
     if (updatedEvent) {
-      try {
-        const updatedMessages =
-          await messageUpdateManager.updateRelatedMessages(updatedEvent);
-        logger.info(
-          `主催者変更によりイベント ${updatedEvent.id} の関連メッセージ ${updatedMessages.length} 件を更新`,
-        );
-      } catch (error) {
-        logger.error(
-          `関連メッセージ更新中にエラーが発生しました: ${String(error)}`,
-        );
-      }
+      messageUpdateManager.enqueue(updatedEvent.id);
+      logger.info(
+        `主催者変更によりイベント ${updatedEvent.id} の関連メッセージ更新をスケジュール`,
+      );
     }
 
     // パネルを表示

--- a/src/commands/action/preparation_status_command/PreparationStatusToggleSelectAction.ts
+++ b/src/commands/action/preparation_status_command/PreparationStatusToggleSelectAction.ts
@@ -103,18 +103,11 @@ class PreparationStatusToggleSelectAction extends MessageComponentActionInteract
       ...eventIncludeHost,
     });
 
-    // パネルなど関連メッセージを更新
-    try {
-      const updatedMessages =
-        await messageUpdateManager.updateRelatedMessages(updated);
-      logger.info(
-        `準備状況変更によりイベント ${event.id} の関連メッセージ ${updatedMessages.length} 件を更新`,
-      );
-    } catch (error) {
-      logger.error(
-        `関連メッセージ更新中にエラーが発生しました: ${String(error)}`,
-      );
-    }
+    // パネルなど関連メッセージの更新をスケジュール
+    messageUpdateManager.enqueue(updated.id);
+    logger.info(
+      `準備状況変更によりイベント ${event.id} の関連メッセージ更新をスケジュール`,
+    );
 
     // 連絡チャンネルに通知
     const contactChannelId = (await import('../../../utils/config.js')).config

--- a/src/commands/event_op_command/EventOpPanelCommand.ts
+++ b/src/commands/event_op_command/EventOpPanelCommand.ts
@@ -95,18 +95,11 @@ class EventOpPanelCommand extends SubcommandInteraction {
         await eventManager.updateEventDescription(scheduledEvent, event);
       }
 
-      // イベントに関連する全メッセージを更新
-      try {
-        const updatedMessages =
-          await messageUpdateManager.updateRelatedMessages(event);
-        logger.info(
-          `主催者変更によりイベント ${event.id} の関連メッセージ ${updatedMessages.length} 件を更新`,
-        );
-      } catch (error) {
-        logger.error(
-          `関連メッセージ更新中にエラーが発生しました: ${String(error)}`,
-        );
-      }
+      // イベントに関連する全メッセージの更新をスケジュール
+      messageUpdateManager.enqueue(event.id);
+      logger.info(
+        `主催者変更によりイベント ${event.id} の関連メッセージ更新をスケジュール`,
+      );
     }
 
     // パネルを表示

--- a/src/message_updaters/MessageUpdateScheduler.ts
+++ b/src/message_updaters/MessageUpdateScheduler.ts
@@ -1,0 +1,115 @@
+import type { EventWithHost } from '../event/EventManager.js';
+import eventManager from '../event/EventManager.js';
+import { logger } from '../utils/log.js';
+import type { MessageUpdateManager } from './MessageUpdateManager.js';
+
+/**
+ * 非同期メッセージ更新スケジューラ
+ * - イベントIDをキューに積み、最後の操作から一定時間後にバッチ実行
+ * - 実行中に新規要求が来た場合は次バッチへ
+ */
+export class MessageUpdateScheduler {
+  private readonly _pendingIds = new Set<number>();
+  private _timer: NodeJS.Timeout | null = null;
+  private _running = false;
+  private _lastEnqueueAt = 0;
+
+  /**
+   * @param _manager メッセージ更新マネージャ
+   * @param _debounceMs デバウンス時間（ミリ秒）
+   */
+  constructor(
+    private readonly _manager: MessageUpdateManager,
+    private readonly _debounceMs = 60_000,
+  ) {}
+
+  /**
+   * 更新要求を追加（イベントIDまたはEventWithHost）
+   * @param event イベントIDまたはイベント
+   */
+  enqueue(event: number | EventWithHost): void {
+    const id = typeof event === 'number' ? event : event.id;
+    this._pendingIds.add(id);
+    this._lastEnqueueAt = Date.now();
+
+    // デバウンス: 既存タイマーがあればリセット
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    this._timer = setTimeout(() => {
+      void this._runBatch();
+    }, this._debounceMs);
+    logger.debug?.(
+      `メッセージ更新を予約: id=${id}, pending=${this._pendingIds.size}`,
+    );
+  }
+
+  /** 保留中を即時実行（デバッグ/緊急用） */
+  async flushNow(): Promise<void> {
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    await this._runBatch();
+  }
+
+  /** バッチ実行本体 */
+  private async _runBatch(): Promise<void> {
+    // 実行中なら、残タスクがあれば再スケジュールのみ行う
+    if (this._running) {
+      this._scheduleNextIfNeeded();
+      return;
+    }
+
+    // 実行スナップショットを取得
+    const batch = Array.from(this._pendingIds);
+    if (batch.length === 0) {
+      return; // 何も無ければ何もしない
+    }
+    this._pendingIds.clear();
+    this._running = true;
+
+    const startedAt = Date.now();
+    logger.info(
+      `メッセージ更新バッチ開始: 件数=${batch.length} ids=[${batch.join(',')}]`,
+    );
+
+    let failed = 0;
+    for (const id of batch) {
+      try {
+        const event = await eventManager.getEventFromId(id);
+        if (!event) continue;
+        await this._manager.updateRelatedMessages(event);
+      } catch (e) {
+        failed += 1;
+        logger.error(`メッセージ更新失敗 (event=${id}): ${String(e)}`);
+      }
+    }
+
+    const elapsed = Date.now() - startedAt;
+    logger.info(
+      `メッセージ更新バッチ終了: 件数=${batch.length}, 失敗=${failed}, 所要=${elapsed}ms`,
+    );
+
+    this._running = false;
+    // 実行中に追加された分があれば再スケジュール
+    this._scheduleNextIfNeeded();
+  }
+
+  /** 残タスクがあれば、lastEnqueueAt + debounceMs にあわせて再スケジュール */
+  private _scheduleNextIfNeeded(): void {
+    if (this._pendingIds.size === 0) return;
+    const delay = Math.max(
+      0,
+      this._lastEnqueueAt + this._debounceMs - Date.now(),
+    );
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    this._timer = setTimeout(() => {
+      void this._runBatch();
+    }, delay);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 関連メッセージ更新を即時実行から一括・遅延処理へ変更。既定で約60秒内の変更をまとめて反映。
  - 複数更新要求を自動で重複排除し、バッチ処理中に一部失敗しても他の更新は継続。
  - 連続操作時のレート制限影響を抑制し、各コマンドの体感応答を改善。
- ドキュメント
  - 非同期メッセージ更新の仕様を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->