### PR TITLE
イベント主催者設定パネルに確定ボタンを追加

### DIFF
--- a/spec/イベントセットアップ確定ボタン.md
+++ b/spec/イベントセットアップ確定ボタン.md
@@ -1,0 +1,26 @@
+- 対象: `/event_creator setup` パネルの主催者/準備者設定フロー
+- 目的: 主催者/準備者変更を即時確定せず、「変更を確定する」ボタンでまとめて反映する
+
+## UI
+- 新規ボタン「変更を確定する」を追加 (Primary)。保留中の変更が無いときは Disabled
+- イベント一覧行に状態マークを表示
+  - 保留中の変更あり: `🟡変更あり`
+  - 変更なし: `✅変更なし`
+- 主催者/準備者のセレクトは従来どおりだが、表示は保留中の選択を優先して反映 (default user)
+
+## 保留状態
+- ユーザーごとのパネル状態に「pendingChanges」を持たせ、イベントIDごとに以下を保持
+  - hostDiscordId
+  - preparerDiscordId
+- セレクト操作時:
+  - DB更新・updateSchedules は行わず pendingChanges へ保存のみ
+  - 既存値と同一なら該当イベントの pendingChanges を削除 (＝変更なし扱い)
+
+## 確定処理
+- 「変更を確定する」押下時に pendingChanges を処理
+  - まだ存在しないイベントは onCreateScheduledEvent で生成してから更新
+  - hostDiscordId / preparerDiscordId を GuildMember→User に解決してから prisma.event.update
+    - preparerId が null の場合は prepareStatus を false にリセット
+  - Discordイベント説明文と関連メッセージ更新を実行 (updateEventDescription, enqueue)
+  - updateSchedules を最後に呼ぶ
+- 成功・スキップ・失敗を1メッセージにまとめて返す。成功後は該当 pending をクリアしパネルを再描画 (ボタン Disabled へ戻る)

--- a/src/commands/action/eventSetupCommand/SetupCancelButtonAction.ts
+++ b/src/commands/action/eventSetupCommand/SetupCancelButtonAction.ts
@@ -1,0 +1,73 @@
+import {
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ComponentType,
+} from 'discord.js';
+import { MessageComponentActionInteraction } from '@/commands/base/actionBase';
+import { eventCreatorSetupCommand } from '@/commands/eventCreatorCommand/EventCreatorSetupCommand';
+
+class SetupCancelButtonAction extends MessageComponentActionInteraction<ComponentType.Button> {
+  /**
+   * ボタンを作成
+   * @param enabled 有効化するかどうか
+   * @returns 作成したビルダー
+   */
+  override create(enabled: boolean): ButtonBuilder {
+    const customId = this.createCustomId();
+
+    return new ButtonBuilder()
+      .setCustomId(customId)
+      .setLabel('変更を取り消す')
+      .setStyle(ButtonStyle.Danger)
+      .setDisabled(!enabled);
+  }
+
+  /** @inheritdoc */
+  async onCommand(
+    interaction: ButtonInteraction,
+    _params: URLSearchParams,
+  ): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const editKey = eventCreatorSetupCommand.key(interaction);
+    const editData = eventCreatorSetupCommand.setupPanels[editKey];
+    if (!editData) {
+      await interaction.editReply({
+        content: 'パネルが賞味期限切れです。もう一度出してやり直してください',
+      });
+      return;
+    }
+
+    if (Object.keys(editData.pendingChanges).length === 0) {
+      await interaction.editReply({
+        content: '取り消す変更がありません。',
+      });
+      return;
+    }
+
+    editData.pendingChanges = {};
+
+    const reply = await eventCreatorSetupCommand.createSetupPanel(interaction);
+    if (!reply) return;
+
+    const panelResult = await editData.interaction
+      .editReply(reply)
+      .catch(() => undefined);
+    if (!panelResult) {
+      await interaction.editReply(reply);
+    }
+
+    await interaction.editReply({
+      content: '保留中の変更を取り消しました。',
+    });
+  }
+}
+
+/**
+ * SetupCancelButtonActionのインスタンス
+ */
+export const setupCancelButtonAction = new SetupCancelButtonAction(
+  'setupcancel',
+  ComponentType.Button,
+);

--- a/src/commands/action/eventSetupCommand/SetupConfirmButtonAction.ts
+++ b/src/commands/action/eventSetupCommand/SetupConfirmButtonAction.ts
@@ -1,0 +1,185 @@
+import {
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ComponentType,
+} from 'discord.js';
+import { MessageComponentActionInteraction } from '@/commands/base/actionBase';
+import { eventCreatorSetupCommand } from '@/commands/eventCreatorCommand/EventCreatorSetupCommand';
+import { eventManager } from '@/domain/services/EventManager';
+import {
+  onCreateScheduledEvent,
+  updateSchedules,
+} from '@/handlers/eventHandler';
+import { prisma } from '@/utils/prisma';
+import { eventIncludeHost } from '@/domain/queries/eventQueries';
+import { messageUpdateManager } from '@/bot/client';
+import { logger } from '@/utils/log';
+import { userManager } from '@/domain/services/UserManager';
+
+class SetupConfirmButtonAction extends MessageComponentActionInteraction<ComponentType.Button> {
+  /**
+   * ボタンを作成
+   * @param enabled 有効化するかどうか
+   * @returns 作成したビルダー
+   */
+  override create(enabled: boolean): ButtonBuilder {
+    const customId = this.createCustomId();
+
+    return new ButtonBuilder()
+      .setCustomId(customId)
+      .setLabel('変更を確定する')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(!enabled);
+  }
+
+  /** @inheritdoc */
+  async onCommand(
+    interaction: ButtonInteraction,
+    _params: URLSearchParams,
+  ): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const editKey = eventCreatorSetupCommand.key(interaction);
+    const editData = eventCreatorSetupCommand.setupPanels[editKey];
+    if (!editData) {
+      await interaction.editReply({
+        content: 'パネルが賞味期限切れです。もう一度出してやり直してください',
+      });
+      return;
+    }
+
+    const pendingEntries = Object.entries(editData.pendingChanges ?? {});
+    if (pendingEntries.length === 0) {
+      await interaction.editReply({ content: '確定する変更がありません。' });
+      return;
+    }
+
+    const results: string[] = [];
+
+    for (const [eventId, pending] of pendingEntries) {
+      const scheduledEvent =
+        eventCreatorSetupCommand.scheduledEvents?.get(eventId) ??
+        (await interaction.guild?.scheduledEvents
+          .fetch(eventId)
+          .catch(() => undefined));
+
+      let event = await eventManager.getEventFromDiscordId(eventId);
+      if (!event) {
+        if (!scheduledEvent) {
+          results.push(
+            `ID: ${eventId} のDiscordイベントが見つかりませんでした`,
+          );
+          continue;
+        }
+        event = (await onCreateScheduledEvent(scheduledEvent)) ?? null;
+        if (!event) {
+          results.push(`イベント(${eventId})の作成に失敗しました`);
+          continue;
+        }
+      }
+
+      const updateData: Parameters<typeof prisma.event.update>[0]['data'] = {};
+
+      if (pending.hostDiscordId !== undefined) {
+        if (pending.hostDiscordId === null) {
+          updateData.hostId = null;
+        } else {
+          const hostMember = await interaction.guild?.members
+            .fetch(pending.hostDiscordId)
+            .catch(() => undefined);
+          if (!hostMember) {
+            results.push(
+              `イベント(${eventId}) 主催者: ユーザー取得に失敗しました`,
+            );
+            continue;
+          }
+          const hostUser = await userManager.getOrCreateUser(hostMember);
+          updateData.hostId = hostUser.id;
+        }
+      }
+
+      if (pending.preparerDiscordId !== undefined) {
+        if (pending.preparerDiscordId === null) {
+          updateData.preparerId = null;
+          updateData.prepareStatus = false;
+        } else {
+          const preparerMember = await interaction.guild?.members
+            .fetch(pending.preparerDiscordId)
+            .catch(() => undefined);
+          if (!preparerMember) {
+            results.push(
+              `イベント(${eventId}) 準備者: ユーザー取得に失敗しました`,
+            );
+            continue;
+          }
+          const preparerUser =
+            await userManager.getOrCreateUser(preparerMember);
+          updateData.preparerId = preparerUser.id;
+        }
+      }
+
+      if (Object.keys(updateData).length === 0) {
+        delete editData.pendingChanges[eventId];
+        continue;
+      }
+
+      const updatedEvent = await prisma.event.update({
+        where: { id: event.id },
+        data: updateData,
+        ...eventIncludeHost,
+      });
+
+      if (scheduledEvent) {
+        await eventManager.updateEventDescription(scheduledEvent, updatedEvent);
+      }
+
+      messageUpdateManager.enqueue(updatedEvent.id);
+      logger.info(`イベント ${updatedEvent.id} の変更を確定`);
+
+      results.push(
+        `イベント(ID: ${updatedEvent.id}) の変更を確定しました。主催者: ${
+          pending.hostDiscordId !== undefined
+            ? pending.hostDiscordId
+              ? `<@${pending.hostDiscordId}>`
+              : 'なし'
+            : '変更なし'
+        } / 準備者: ${
+          pending.preparerDiscordId !== undefined
+            ? pending.preparerDiscordId
+              ? `<@${pending.preparerDiscordId}>`
+              : 'なし'
+            : '変更なし'
+        }`,
+      );
+
+      delete editData.pendingChanges[eventId];
+    }
+
+    await updateSchedules();
+
+    const reply = await eventCreatorSetupCommand.createSetupPanel(interaction);
+    if (reply) {
+      const panelResult = await editData.interaction
+        .editReply(reply)
+        .catch(() => undefined);
+      if (!panelResult) {
+        await interaction.editReply(reply);
+      }
+    }
+
+    await interaction.editReply({
+      content: results.length
+        ? results.join('\n')
+        : '変更が反映されませんでした。対象イベントが見つかりませんでした。',
+    });
+  }
+}
+
+/**
+ * SetupConfirmButtonActionのインスタンス
+ */
+export const setupConfirmButtonAction = new SetupConfirmButtonAction(
+  'setupconfirm',
+  ComponentType.Button,
+);

--- a/src/commands/action/eventSetupCommand/commands.ts
+++ b/src/commands/action/eventSetupCommand/commands.ts
@@ -2,6 +2,7 @@ import { InteractionBase } from '@/commands/base/interactionBase';
 import { setupEventSelectAction } from './SetupEventSelectAction';
 import { setupUserSelectAction } from './SetupUserSelectAction';
 import { setupPreparerSelectAction } from './SetupPreparerSelectAction';
+import { setupConfirmButtonAction } from './SetupConfirmButtonAction';
 
 /**
  * イベントセットアップアクションの配列
@@ -10,4 +11,5 @@ export const eventSetupActions: InteractionBase[] = [
   setupEventSelectAction,
   setupUserSelectAction,
   setupPreparerSelectAction,
+  setupConfirmButtonAction,
 ];

--- a/src/commands/action/eventSetupCommand/commands.ts
+++ b/src/commands/action/eventSetupCommand/commands.ts
@@ -3,6 +3,7 @@ import { setupEventSelectAction } from './SetupEventSelectAction';
 import { setupUserSelectAction } from './SetupUserSelectAction';
 import { setupPreparerSelectAction } from './SetupPreparerSelectAction';
 import { setupConfirmButtonAction } from './SetupConfirmButtonAction';
+import { setupCancelButtonAction } from './SetupCancelButtonAction';
 
 /**
  * イベントセットアップアクションの配列
@@ -11,5 +12,6 @@ export const eventSetupActions: InteractionBase[] = [
   setupEventSelectAction,
   setupUserSelectAction,
   setupPreparerSelectAction,
+  setupCancelButtonAction,
   setupConfirmButtonAction,
 ];

--- a/src/commands/eventCreatorCommand/EventCreatorSetupCommand.ts
+++ b/src/commands/eventCreatorCommand/EventCreatorSetupCommand.ts
@@ -149,30 +149,7 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
 
     // イベントとイベント主催者の表を表示
     const eventTable = eventList
-      .map(({ event, scheduledEvent, pendingChange }) => {
-        const date = event?.scheduleTime ?? scheduledEvent.scheduledStartAt;
-        const dateStr = date
-          ? `<t:${Math.floor(date.getTime() / 1000)}:D>`
-          : '未定';
-        const eventInfo = `${dateStr} [「${event?.name ?? scheduledEvent?.name ?? '？'}」(ID: ${event?.id ?? '？'})](https://discord.com/events/${config.guild_id}/${scheduledEvent.id})`;
-        const hostDiscordId = this.resolvePendingMemberDiscordId(
-          event,
-          pendingChange,
-          'hostDiscordId',
-        );
-        const preparerDiscordId = this.resolvePendingMemberDiscordId(
-          event,
-          pendingChange,
-          'preparerDiscordId',
-        );
-        const hostName = hostDiscordId ? `<@${hostDiscordId}>` : 'なし';
-        const preparerDisplay = preparerDiscordId
-          ? ` / 準備者: <@${preparerDiscordId}>`
-          : '';
-        const changeMark = pendingChange ? '🟡' : '';
-
-        return `${changeMark} ${eventInfo}: 主催者: ${hostName}${preparerDisplay}`;
-      })
+      .map((eventSpec) => this.formatEventSummary(eventSpec))
       .join('\n');
 
     // パネルを作成
@@ -216,6 +193,39 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
         ),
       ],
     };
+  }
+
+  formatEventSummary(eventSpec: EventSpec): string {
+    const { event, scheduledEvent, pendingChange } = eventSpec;
+    const date = event?.scheduleTime ?? scheduledEvent.scheduledStartAt;
+    const dateStr = date
+      ? `<t:${Math.floor(date.getTime() / 1000)}:D>`
+      : '未定';
+    const eventTitle = event?.name ?? scheduledEvent?.name ?? '？';
+    const eventId = event?.id ?? '未生成';
+    const changeMark = pendingChange ? ' 🟡' : '';
+    const eventLink = `https://discord.com/events/${config.guild_id}/${scheduledEvent.id}`;
+    const hostDiscordId = this.resolvePendingMemberDiscordId(
+      event,
+      pendingChange,
+      'hostDiscordId',
+    );
+    const preparerDiscordId = this.resolvePendingMemberDiscordId(
+      event,
+      pendingChange,
+      'preparerDiscordId',
+    );
+    const hostDisplay = hostDiscordId ? `<@${hostDiscordId}>` : 'なし';
+    const summaryLines = [
+      `### ${dateStr} [${eventTitle}](${eventLink}) (ID: ${eventId})${changeMark}`,
+      `- 主催者: ${hostDisplay}`,
+    ];
+
+    if (preparerDiscordId) {
+      summaryLines.push(`- 準備者: <@${preparerDiscordId}>`);
+    }
+
+    return summaryLines.join('\n');
   }
 
   resolvePendingMemberDiscordId(

--- a/src/commands/eventCreatorCommand/EventCreatorSetupCommand.ts
+++ b/src/commands/eventCreatorCommand/EventCreatorSetupCommand.ts
@@ -18,6 +18,7 @@ import { setupUserSelectAction } from '@/commands/action/eventSetupCommand/Setup
 import { setupPreparerSelectAction } from '@/commands/action/eventSetupCommand/SetupPreparerSelectAction';
 import { setupEventSelectAction } from '@/commands/action/eventSetupCommand/SetupEventSelectAction';
 import { setupConfirmButtonAction } from '@/commands/action/eventSetupCommand/SetupConfirmButtonAction';
+import { setupCancelButtonAction } from '@/commands/action/eventSetupCommand/SetupCancelButtonAction';
 import { prisma } from '@/utils/prisma';
 import { eventCreatorCommand } from './EventCreatorCommand';
 import { eventIncludeHost, EventWithHost } from '@/domain/queries/eventQueries';
@@ -188,6 +189,9 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
         ),
         new ActionRowBuilder<ButtonBuilder>().addComponents(
           setupConfirmButtonAction.create(
+            eventList.some((event) => Boolean(event.pendingChange)),
+          ),
+          setupCancelButtonAction.create(
             eventList.some((event) => Boolean(event.pendingChange)),
           ),
         ),

--- a/src/commands/eventCreatorCommand/EventCreatorSetupCommand.ts
+++ b/src/commands/eventCreatorCommand/EventCreatorSetupCommand.ts
@@ -1,5 +1,6 @@
 import {
   ActionRowBuilder,
+  ButtonBuilder,
   ChatInputCommandInteraction,
   Collection,
   EmbedBuilder,
@@ -16,9 +17,24 @@ import { config } from '@/bot/config';
 import { setupUserSelectAction } from '@/commands/action/eventSetupCommand/SetupUserSelectAction';
 import { setupPreparerSelectAction } from '@/commands/action/eventSetupCommand/SetupPreparerSelectAction';
 import { setupEventSelectAction } from '@/commands/action/eventSetupCommand/SetupEventSelectAction';
+import { setupConfirmButtonAction } from '@/commands/action/eventSetupCommand/SetupConfirmButtonAction';
 import { prisma } from '@/utils/prisma';
 import { eventCreatorCommand } from './EventCreatorCommand';
 import { eventIncludeHost, EventWithHost } from '@/domain/queries/eventQueries';
+
+/**
+ * 保留中の変更
+ */
+export interface PendingChange {
+  /**
+   * 主催者DiscordID
+   */
+  hostDiscordId?: string | null;
+  /**
+   * 準備者DiscordID
+   */
+  preparerDiscordId?: string | null;
+}
 
 /**
  * イベント情報
@@ -32,6 +48,10 @@ export interface EventSpec {
    * イベント
    */
   event?: EventWithHost;
+  /**
+   * 保留中の変更
+   */
+  pendingChange?: PendingChange;
 }
 
 /**
@@ -40,6 +60,7 @@ export interface EventSpec {
 interface EditData {
   interaction: RepliableInteraction;
   selectedEvent: string;
+  pendingChanges: Record<string, PendingChange>;
 }
 
 class EventCreatorSetupCommand extends SubcommandInteraction {
@@ -92,6 +113,8 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
       return;
     }
 
+    const cachedEditData = this.setupPanels[this.key(interaction)];
+
     // イベントを取得
     const events = await prisma.event.findMany({
       where: {
@@ -105,9 +128,13 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
     const eventList: EventSpec[] = scheduledEvents
       .map((scheduledEvent) => {
         const event = events.find((e) => e.eventId === scheduledEvent.id);
+        const pendingChange =
+          cachedEditData?.pendingChanges[scheduledEvent.id] ?? undefined;
+
         return {
           scheduledEvent,
           event,
+          pendingChange,
         };
       })
       .sort(
@@ -122,20 +149,29 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
 
     // イベントとイベント主催者の表を表示
     const eventTable = eventList
-      .map(({ event, scheduledEvent }) => {
+      .map(({ event, scheduledEvent, pendingChange }) => {
         const date = event?.scheduleTime ?? scheduledEvent.scheduledStartAt;
         const dateStr = date
           ? `<t:${Math.floor(date.getTime() / 1000)}:D>`
           : '未定';
         const eventInfo = `${dateStr} [「${event?.name ?? scheduledEvent?.name ?? '？'}」(ID: ${event?.id ?? '？'})](https://discord.com/events/${config.guild_id}/${scheduledEvent.id})`;
-        const hostName = event?.host?.userId
-          ? `<@${event.host.userId}>`
-          : 'なし';
-        const preparerDisplay = event?.preparer?.userId
-          ? ` / 準備者: <@${event.preparer.userId}>`
+        const hostDiscordId = this.resolvePendingMemberDiscordId(
+          event,
+          pendingChange,
+          'hostDiscordId',
+        );
+        const preparerDiscordId = this.resolvePendingMemberDiscordId(
+          event,
+          pendingChange,
+          'preparerDiscordId',
+        );
+        const hostName = hostDiscordId ? `<@${hostDiscordId}>` : 'なし';
+        const preparerDisplay = preparerDiscordId
+          ? ` / 準備者: <@${preparerDiscordId}>`
           : '';
+        const changeMark = pendingChange ? '🟡' : '';
 
-        return `${eventInfo}: 主催者: ${hostName}${preparerDisplay}`;
+        return `${changeMark} ${eventInfo}: 主催者: ${hostName}${preparerDisplay}`;
       })
       .join('\n');
 
@@ -153,6 +189,7 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
       interaction,
       selectedEvent:
         editData?.selectedEvent ?? eventList[0]?.scheduledEvent.id ?? '',
+      pendingChanges: editData?.pendingChanges ?? {},
     };
 
     // 選択中のイベントを取得
@@ -172,8 +209,76 @@ class EventCreatorSetupCommand extends SubcommandInteraction {
         new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(
           setupPreparerSelectAction.create(selectedEvent),
         ),
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          setupConfirmButtonAction.create(
+            eventList.some((event) => Boolean(event.pendingChange)),
+          ),
+        ),
       ],
     };
+  }
+
+  resolvePendingMemberDiscordId(
+    event: EventWithHost | undefined,
+    pendingChange: PendingChange | undefined,
+    key: keyof PendingChange,
+  ): string | null {
+    const currentDiscordId =
+      key === 'hostDiscordId'
+        ? (event?.host?.userId ?? null)
+        : (event?.preparer?.userId ?? null);
+
+    if (pendingChange?.[key] === undefined) {
+      return currentDiscordId;
+    }
+
+    return pendingChange[key] ?? null;
+  }
+
+  updatePendingChanges(
+    editData: EditData,
+    eventId: string,
+    change: PendingChange,
+    baseEvent?: EventWithHost | null,
+  ): void {
+    const currentHostDiscordId = baseEvent?.host?.userId ?? null;
+    const currentPreparerDiscordId = baseEvent?.preparer?.userId ?? null;
+    const previousPending = editData.pendingChanges[eventId] ?? {};
+
+    const nextHostDiscordId =
+      change.hostDiscordId !== undefined
+        ? change.hostDiscordId
+        : previousPending.hostDiscordId;
+    const nextPreparerDiscordId =
+      change.preparerDiscordId !== undefined
+        ? change.preparerDiscordId
+        : previousPending.preparerDiscordId;
+
+    const pending: PendingChange = {};
+
+    if (
+      nextHostDiscordId !== undefined &&
+      nextHostDiscordId !== currentHostDiscordId
+    ) {
+      pending.hostDiscordId = nextHostDiscordId ?? null;
+    }
+
+    if (
+      nextPreparerDiscordId !== undefined &&
+      nextPreparerDiscordId !== currentPreparerDiscordId
+    ) {
+      pending.preparerDiscordId = nextPreparerDiscordId ?? null;
+    }
+
+    if (
+      pending.hostDiscordId === undefined &&
+      pending.preparerDiscordId === undefined
+    ) {
+      delete editData.pendingChanges[eventId];
+      return;
+    }
+
+    editData.pendingChanges[eventId] = pending;
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * イベント設定の変更を一時保存できる保留フローを追加（各イベントに🟡/✅で状態表示）
  * 一括で確定する「変更を確定する」ボタンと、保留を取り消す「キャンセル」ボタンを追加
  * 確定時に保留中のホスト／準備者変更を反映し、処理結果をまとめて通知

* **改善**
  * 確定ボタンは保留が無い場合に無効化されるように変更

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->